### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  brakeman:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - '2.7'
+          - '3.0'
+          - '3.1'
+    name: Ruby ${{ matrix.ruby }} tests
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - run: bundle exec rake test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/Gemfile.lock
 rdoc

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/stemmify.gemspec
+++ b/stemmify.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 #  s.rubygems_version = "0.0.1"
   s.summary = "Stemming reducing an inflected word to its root form (approximately). For example, running reduces to run."
-  s.add_development_dependency('rdoc', '>=3.9.1')
-end
 
+  s.add_development_dependency 'rake'
+  s.add_development_dependency('rdoc', '>=3.9.1')
+  s.add_development_dependency 'test-unit'
+end


### PR DESCRIPTION
Even though [more versions of Ruby are provided by `ruby/setup-ruby`](https://github.com/ruby/setup-ruby#supported-versions) I only added Ruby version 2.7, 3.0, and 3.1 because they're the [current officially-supported versions](https://www.ruby-lang.org/en/downloads/).

You can see a successful job run here: https://github.com/benpickles/stemmify/actions/runs/2852575061